### PR TITLE
Improving get_menu_item to handle correctly max_depth.

### DIFF
--- a/cms.py
+++ b/cms.py
@@ -226,10 +226,11 @@ class MenuItem(ModelSQL, ModelView, CMSMenuItemMixin):
             res['record'] = self.record
             res['link'] = self.record.get_absolute_url()
 
-        if max_depth:
+        if max_depth > 0:
             res['children'] = self.get_children(max_depth=max_depth - 1)
 
-        if self.type_ == 'record' and not res.get('children') and max_depth:
+        if (self.type_ == 'record' and not res.get('children')
+                and max_depth > 0):
             res['children'] = self.record.get_children(
                 max_depth=max_depth - 1
             )


### PR DESCRIPTION
There can be scenarios where max_depth gets a negative value, e.g. by
calling get_children directly. Currently this leads to the parsing
of the whole tree. Only taking positive values into account provides
the intended behavior.